### PR TITLE
docs: update license reference to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2019-2022 GuideSmiths Ltd.
 Copyright (c) 2021 Guidesmiths
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "error-handler-module",
       "version": "1.0.6",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "http-status-codes": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jest"
   ],
   "author": "Kevin Martínez (kevin.martinez@guidesmiths.com)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/guidesmiths/error-handler-module/issues"
   },


### PR DESCRIPTION
## Main changes

Updated license references to MIT

## Context

Related https://github.com/onebeyond/admin/issues/27